### PR TITLE
Point MAINTAINERS to the one in the main Emissary repo

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,6 +5,6 @@ describes governance guidelines and maintainer responsibilities.
 
 ## Maintainers
 
-[MAINTAINERS.md](https://github.com/emissary-ingress/emissary/blob/main/MAINTAINERS.md)
+[MAINTAINERS.md](https://github.com/emissary-ingress/emissary/blob/master/MAINTAINERS.md)
 in [the main Emissary-ingress repo](https://github.com/emissary-ingress/emissary) lists
 the current Emissary-ingress maintainers and releasers.


### PR DESCRIPTION
Rather than trying to keep both files up to date, point this one at
the other one. (I don't want to point the other one here because I
expect most people contributing to look at the Emissary repo rather
than the community repo.)

Signed-off-by: Flynn <emissary@flynn.kodachi.com>
